### PR TITLE
Add Docker Model Runner backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@ OLLAMA_BASE_URL='http://localhost:11434'
 OPENAI_API_BASE_URL=''
 OPENAI_API_KEY=''
 
+# Docker Model Runner API base URL
+DMR_BASE_URL='http://localhost:12434'
+
 # AUTOMATIC1111_BASE_URL="http://localhost:7860"
 
 # For production, you should only need one host as

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For more information, be sure to check out our [Open WebUI Documentation](https:
 
 - 🚀 **Effortless Setup**: Install seamlessly using Docker or Kubernetes (kubectl, kustomize or helm) for a hassle-free experience with support for both `:ollama` and `:cuda` tagged images.
 
-- 🤝 **Ollama/OpenAI API Integration**: Effortlessly integrate OpenAI-compatible APIs for versatile conversations alongside Ollama models. Customize the OpenAI API URL to link with **LMStudio, GroqCloud, Mistral, OpenRouter, and more**.
+- 🤝 **Ollama/OpenAI API Integration**: Effortlessly integrate OpenAI-compatible APIs for versatile conversations alongside Ollama models. Customize the OpenAI API URL to link with **LMStudio, GroqCloud, Mistral, OpenRouter, Docker Model Runner, and more**.
 
 - 🛡️ **Granular Permissions and User Groups**: By allowing administrators to create detailed user roles and permissions, we ensure a secure user environment. This granularity not only enhances security but also allows for customized user experiences, fostering a sense of ownership and responsibility amongst users.
 
@@ -164,6 +164,14 @@ This will start the Open WebUI server, which you can access at [http://localhost
   ```bash
   docker run -d -p 3000:8080 -e OPENAI_API_KEY=your_secret_key -v open-webui:/app/backend/data --name open-webui --restart always ghcr.io/open-webui/open-webui:main
   ```
+
+### Using Docker Model Runner
+
+Enable Docker Model Runner in Docker Desktop and set the `DMR_BASE_URL` environment variable to the exposed API endpoint:
+
+```bash
+docker run -d -p 3000:8080 -e DMR_BASE_URL=http://localhost:12434 -v open-webui:/app/backend/data --name open-webui --restart always ghcr.io/open-webui/open-webui:main
+```
 
 ### Installing Open WebUI with Bundled Ollama Support
 

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -896,6 +896,36 @@ except Exception:
 OPENAI_API_BASE_URL = "https://api.openai.com/v1"
 
 ####################################
+# DOCKER MODEL RUNNER
+####################################
+
+ENABLE_DMR_API = PersistentConfig(
+    "ENABLE_DMR_API",
+    "dmr.enable",
+    os.environ.get("ENABLE_DMR_API", "True").lower() == "true",
+)
+
+DMR_API_KEYS = [k.strip() for k in os.environ.get("DMR_API_KEYS", "").split(";")]
+DMR_API_KEYS = PersistentConfig("DMR_API_KEYS", "dmr.api_keys", DMR_API_KEYS)
+
+DMR_BASE_URL = os.environ.get("DMR_BASE_URL", "")
+if DMR_BASE_URL:
+    DMR_BASE_URL = DMR_BASE_URL[:-1] if DMR_BASE_URL.endswith("/") else DMR_BASE_URL
+
+DMR_BASE_URLS = os.environ.get("DMR_BASE_URLS", "")
+DMR_BASE_URLS = DMR_BASE_URLS if DMR_BASE_URLS != "" else DMR_BASE_URL or "http://localhost:12434"
+DMR_BASE_URLS = [url.strip() for url in DMR_BASE_URLS.split(";")]
+DMR_BASE_URLS = PersistentConfig(
+    "DMR_BASE_URLS", "dmr.base_urls", DMR_BASE_URLS
+)
+
+DMR_API_CONFIGS = PersistentConfig(
+    "DMR_API_CONFIGS",
+    "dmr.api_configs",
+    {},
+)
+
+####################################
 # TOOL_SERVERS
 ####################################
 

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -63,6 +63,7 @@ from open_webui.routers import (
     images,
     ollama,
     openai,
+    docker_model_runner,
     retrieval,
     pipelines,
     tasks,
@@ -112,6 +113,11 @@ from open_webui.config import (
     OPENAI_API_BASE_URLS,
     OPENAI_API_KEYS,
     OPENAI_API_CONFIGS,
+    # Docker Model Runner
+    ENABLE_DMR_API,
+    DMR_BASE_URLS,
+    DMR_API_KEYS,
+    DMR_API_CONFIGS,
     # Direct Connections
     ENABLE_DIRECT_CONNECTIONS,
     # Thread pool size for FastAPI/AnyIO
@@ -588,6 +594,19 @@ app.state.config.OPENAI_API_KEYS = OPENAI_API_KEYS
 app.state.config.OPENAI_API_CONFIGS = OPENAI_API_CONFIGS
 
 app.state.OPENAI_MODELS = {}
+
+########################################
+#
+# DOCKER MODEL RUNNER
+#
+########################################
+
+app.state.config.ENABLE_DMR_API = ENABLE_DMR_API
+app.state.config.DMR_BASE_URLS = DMR_BASE_URLS
+app.state.config.DMR_API_KEYS = DMR_API_KEYS
+app.state.config.DMR_API_CONFIGS = DMR_API_CONFIGS
+
+app.state.DMR_MODELS = {}
 
 ########################################
 #
@@ -1111,6 +1130,7 @@ app.mount("/ws", socket_app)
 
 app.include_router(ollama.router, prefix="/ollama", tags=["ollama"])
 app.include_router(openai.router, prefix="/openai", tags=["openai"])
+app.include_router(docker_model_runner.router, prefix="/dmr", tags=["dmr"])
 
 
 app.include_router(pipelines.router, prefix="/api/v1/pipelines", tags=["pipelines"])

--- a/backend/open_webui/routers/docker_model_runner.py
+++ b/backend/open_webui/routers/docker_model_runner.py
@@ -1,0 +1,110 @@
+from contextlib import contextmanager
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Request
+from pydantic import BaseModel
+
+from open_webui.models.users import UserModel
+from open_webui.routers import openai
+from open_webui.routers.openai import ConnectionVerificationForm
+from open_webui.utils.auth import get_admin_user, get_verified_user
+
+router = APIRouter()
+
+@contextmanager
+def _dmr_context(request: Request):
+    orig_urls = request.app.state.config.OPENAI_API_BASE_URLS
+    orig_keys = request.app.state.config.OPENAI_API_KEYS
+    orig_configs = request.app.state.config.OPENAI_API_CONFIGS
+    orig_models = request.app.state.OPENAI_MODELS
+    request.app.state.config.OPENAI_API_BASE_URLS = request.app.state.config.DMR_BASE_URLS
+    request.app.state.config.OPENAI_API_KEYS = request.app.state.config.DMR_API_KEYS
+    request.app.state.config.OPENAI_API_CONFIGS = request.app.state.config.DMR_API_CONFIGS
+    request.app.state.OPENAI_MODELS = request.app.state.DMR_MODELS
+    try:
+        yield
+    finally:
+        request.app.state.config.OPENAI_API_BASE_URLS = orig_urls
+        request.app.state.config.OPENAI_API_KEYS = orig_keys
+        request.app.state.config.OPENAI_API_CONFIGS = orig_configs
+        request.app.state.OPENAI_MODELS = orig_models
+
+
+@router.get("/config")
+async def get_config(request: Request, user=Depends(get_admin_user)):
+    return {
+        "ENABLE_DMR_API": request.app.state.config.ENABLE_DMR_API,
+        "DMR_BASE_URLS": request.app.state.config.DMR_BASE_URLS,
+        "DMR_API_KEYS": request.app.state.config.DMR_API_KEYS,
+        "DMR_API_CONFIGS": request.app.state.config.DMR_API_CONFIGS,
+    }
+
+
+class DMRConfigForm(BaseModel):
+    ENABLE_DMR_API: Optional[bool] = None
+    DMR_BASE_URLS: list[str]
+    DMR_API_KEYS: list[str] = []
+    DMR_API_CONFIGS: dict = {}
+
+
+@router.post("/config/update")
+async def update_config(request: Request, form_data: DMRConfigForm, user=Depends(get_admin_user)):
+    request.app.state.config.ENABLE_DMR_API = form_data.ENABLE_DMR_API
+    request.app.state.config.DMR_BASE_URLS = form_data.DMR_BASE_URLS
+    request.app.state.config.DMR_API_KEYS = form_data.DMR_API_KEYS
+    request.app.state.config.DMR_API_CONFIGS = form_data.DMR_API_CONFIGS
+
+    if len(request.app.state.config.DMR_API_KEYS) != len(request.app.state.config.DMR_BASE_URLS):
+        if len(request.app.state.config.DMR_API_KEYS) > len(request.app.state.config.DMR_BASE_URLS):
+            request.app.state.config.DMR_API_KEYS = request.app.state.config.DMR_API_KEYS[: len(request.app.state.config.DMR_BASE_URLS)]
+        else:
+            request.app.state.config.DMR_API_KEYS += [""] * (
+                len(request.app.state.config.DMR_BASE_URLS) - len(request.app.state.config.DMR_API_KEYS)
+            )
+
+    keys = list(map(str, range(len(request.app.state.config.DMR_BASE_URLS))))
+    request.app.state.config.DMR_API_CONFIGS = {
+        k: v for k, v in request.app.state.config.DMR_API_CONFIGS.items() if k in keys
+    }
+
+    return {
+        "ENABLE_DMR_API": request.app.state.config.ENABLE_DMR_API,
+        "DMR_BASE_URLS": request.app.state.config.DMR_BASE_URLS,
+        "DMR_API_KEYS": request.app.state.config.DMR_API_KEYS,
+        "DMR_API_CONFIGS": request.app.state.config.DMR_API_CONFIGS,
+    }
+
+
+@router.post("/verify")
+async def verify_connection(form_data: ConnectionVerificationForm, user=Depends(get_admin_user)):
+    return await openai.verify_connection(form_data, user)
+
+
+@router.get("/models")
+@router.get("/models/{url_idx}")
+async def get_models(request: Request, url_idx: Optional[int] = None, user=Depends(get_verified_user)):
+    with _dmr_context(request):
+        return await openai.get_models(request, url_idx=url_idx, user=user)
+
+
+@router.post("/chat/completions")
+async def generate_chat_completion(request: Request, form_data: dict, user=Depends(get_verified_user)):
+    with _dmr_context(request):
+        return await openai.generate_chat_completion(request, form_data, user=user)
+
+
+@router.post("/completions")
+async def completions(request: Request, form_data: dict, user=Depends(get_verified_user)):
+    with _dmr_context(request):
+        return await openai.completions(request, form_data, user=user)
+
+
+@router.post("/embeddings")
+async def embeddings(request: Request, form_data: dict, user=Depends(get_verified_user)):
+    with _dmr_context(request):
+        return await openai.embeddings(request, form_data, user=user)
+
+
+async def get_all_models(request: Request, user: UserModel = None):
+    with _dmr_context(request):
+        return await openai.get_all_models.__wrapped__(request, user)


### PR DESCRIPTION
## Summary
- support Docker Model Runner through a new `dmr` provider
- wire config values and router in the backend
- include Docker Model Runner models when listing models
- document Docker Model Runner setup
- expose `DMR_BASE_URL` in example environment file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'boto3')*

------
https://chatgpt.com/codex/tasks/task_e_684ee8ef06f48326b026c580fd92814f